### PR TITLE
Revert apiclient-services

### DIFF
--- a/php/lib/google-api-php-client/composer.json
+++ b/php/lib/google-api-php-client/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.4",
         "google/auth": "^1.10",
-        "google/apiclient-services": "~0.20",
+        "google/apiclient-services": "~0.13",
         "firebase/php-jwt": "~2.0||~3.0||~4.0||~5.0",
         "monolog/monolog": "^1.17|^2.0",
         "phpseclib/phpseclib": "~0.3.10||~2.0",


### PR DESCRIPTION
Revert the apiclient-services back to 0.13, The Google API Client library is at 2.8.0. Supporting changes are required before this library is brought to the most recent release of 2.11.0